### PR TITLE
Refactor Icon Button Styling Logic

### DIFF
--- a/frontend/app/(auth)/index.tsx
+++ b/frontend/app/(auth)/index.tsx
@@ -6,11 +6,9 @@ import { PrimaryButton, InputField, IconButton } from '@/components';
 import { router } from 'expo-router';
 import { useColorScheme } from 'react-native';
 
-
-
 const Login = () => {
   const colorScheme = useColorScheme();
-  const appleIconColor = colorScheme === 'dark' ? '#FFF' : '#000';
+
   return (
     <View className='flex-1 bg-bg-light dark:bg-bg-dark'>
       <SafeAreaView className='flex-1 px-6'>
@@ -41,7 +39,7 @@ const Login = () => {
             </View>
             <View className='flex-row gap-x-4'>
               <IconButton icon={images.google} onPress={() => {}} />
-              <IconButton icon={images.apple} onPress={() => {}} tintColor={appleIconColor}/>
+              <IconButton icon={images.apple} tintColor={colorScheme === 'dark' ? '#FFF' : '#000'} onPress={() => {}} />
             </View>
             <View className='flex-row justify-center gap-x-1'>
               <Text className='text-sm font-poppins-medium dark:text-white'>{strings.login.NO_ACCOUNT_TEXT}</Text>

--- a/frontend/app/(auth)/signup.tsx
+++ b/frontend/app/(auth)/signup.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Image, Pressable } from 'react-native';
+import { View, Text, Image, Pressable, useColorScheme } from 'react-native';
 import { images } from '@/assets';
 import { strings } from '@/constants';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -6,6 +6,8 @@ import { PrimaryButton, InputField, IconButton } from '@/components';
 import { router } from 'expo-router';
 
 const Signup = () => {
+  const colorScheme = useColorScheme();
+
   return (
     <View className='flex-1 bg-bg-light dark:bg-bg-dark'>
       <SafeAreaView className='flex-1 px-6'>
@@ -35,7 +37,7 @@ const Signup = () => {
             </View>
             <View className='flex-row gap-x-4'>
               <IconButton icon={images.google} onPress={() => {}} />
-              <IconButton icon={images.apple} onPress={() => {}} />
+              <IconButton icon={images.apple} tintColor={colorScheme === 'dark' ? '#FFF' : '#000'} onPress={() => {}} />
             </View>
             <View className='flex-row justify-center gap-x-1'>
               <Text className='text-sm font-poppins-medium dark:text-white'>{strings.signup.NO_ACCOUNT_TEXT}</Text>

--- a/frontend/components/IconButton.tsx
+++ b/frontend/components/IconButton.tsx
@@ -53,7 +53,7 @@ const IconButton = (props: IconButtonProps) => {
       onPressIn={handlePressIn}
       className='flex-1 p-px rounded-2xl items-center justify-center overflow-hidden bg-card-bg-light dark:bg-card-bg-dark'
     >
-      <View ref={containerRef} className='w-full py-4 rounded-2xl border border-text-secondary-light dark:border-text-secondary-dark'>
+      <View ref={containerRef} className='w-full py-5 rounded-2xl border border-text-secondary-light dark:border-text-secondary-dark'>
         <Animated.View style={animatedRippleStyle} />
         <Image source={props.icon} className='h-5 w-5 mx-auto' resizeMode='contain' style={props.tintColor ? { tintColor: props.tintColor } : undefined} />
       </View>

--- a/frontend/components/IconButton.tsx
+++ b/frontend/components/IconButton.tsx
@@ -55,7 +55,7 @@ const IconButton = (props: IconButtonProps) => {
     >
       <View ref={containerRef} className='flex-1 justify-center items-center w-full h-full'>
         <Animated.View style={animatedRippleStyle} />
-        <Image source={props.icon} className='h-5 w-5' resizeMode='contain' style={props.tintColor ? { tintColor: props.tintColor } : undefined}/>
+        <Image source={props.icon} className='h-5 w-5' resizeMode='contain' style={props.tintColor ? { tintColor: props.tintColor } : undefined} />
       </View>
     </Pressable>
   );

--- a/frontend/components/IconButton.tsx
+++ b/frontend/components/IconButton.tsx
@@ -51,11 +51,11 @@ const IconButton = (props: IconButtonProps) => {
     <Pressable
       onPress={props.onPress}
       onPressIn={handlePressIn}
-      className='flex-1 py-6 rounded-2xl items-center justify-center overflow-hidden bg-card-bg-light dark:bg-card-bg-dark border-[0.2px] border-text-secondary-light dark:border-text-primary-dark'
+      className='flex-1 p-px rounded-2xl items-center justify-center overflow-hidden bg-card-bg-light dark:bg-card-bg-dark'
     >
-      <View ref={containerRef} className='flex-1 justify-center items-center w-full h-full'>
+      <View ref={containerRef} className='w-full py-4 rounded-2xl border border-text-secondary-light dark:border-text-secondary-dark'>
         <Animated.View style={animatedRippleStyle} />
-        <Image source={props.icon} className='h-5 w-5' resizeMode='contain' style={props.tintColor ? { tintColor: props.tintColor } : undefined} />
+        <Image source={props.icon} className='h-5 w-5 mx-auto' resizeMode='contain' style={props.tintColor ? { tintColor: props.tintColor } : undefined} />
       </View>
     </Pressable>
   );


### PR DESCRIPTION
## 🚀 Summary

Includes logic and styling refinements to the Apple icon and `IconButton` components across the Login and Signup screens:
- Optimized the color logic for the Apple Icon on the Login screen
- Passed tint prop to Apple `IconButton` on the Signup screen for consistent styling
- Increased vertical padding for better touch targets and visual balance
- Removed the outer border from `IconButton` for a cleaner look
- Added an inner border to `IconButton` to maintain subtle visual structure

## 🧩 Related Issues / Tasks

- Closes #2 
- Closes #3 

## 🛠️ Type of Change

- [X] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 🧨 Breaking change
- [X] 🔨 Enhancement/Refactor
- [ ] 📝 Documentation
- [ ] 📜 Other (please describe):

## ✅ Checklist

- [X] The code is formatted with **Prettier** (`npm run format` or `npx prettier --write .`)
- [X] PR references a linked **Issue** or **Task number**
- [X] Tested on both iOS and Android devices/emulators
- [X] No unnecessary logs or commented-out code
- [X] UI changes, if any, have been reviewed visually
- [ ] All tests are passing (if applicable)
- [ ] Added or updated documentation where necessary

## 📸 Screenshots / Videos (UI changes only)

### Before

<img src='https://github.com/user-attachments/assets/b69f5465-d5e3-4b5c-99c2-1a8f43b89a1a' width='160' />

### After
<img src='https://github.com/user-attachments/assets/1f7e6198-4e28-49dd-b88c-a5c4ecfb6a23' width='160' />

## 🧪 Test Plan

Tested visually and attached before-after screenshot of the Signup screen above.
