### PR TITLE
Adds Light theme styling to RoundIconButton

### DIFF
--- a/frontend/components/RoundIconButton.tsx
+++ b/frontend/components/RoundIconButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Image, ImageSourcePropType, GestureResponderEvent, Pressable, View } from 'react-native';
+import { Image, ImageSourcePropType, GestureResponderEvent, Pressable, View, useColorScheme } from 'react-native';
 
 interface RoundIconButtonProps {
   primaryIcon: ImageSourcePropType;
@@ -9,6 +9,7 @@ interface RoundIconButtonProps {
 
 const RoundIconButton = (props: RoundIconButtonProps) => {
   const [isPrimary, setIsPrimary] = useState(true);
+  const colorScheme = useColorScheme();
 
   const handlePress = (e: GestureResponderEvent) => {
     if (props.secondaryIcon) {
@@ -22,7 +23,7 @@ const RoundIconButton = (props: RoundIconButtonProps) => {
   return (
     <Pressable onPress={handlePress} className='p-1.5 rounded-full'>
       {/* Background layer with opacity */}
-      <View className='absolute inset-0 rounded-full bg-[#3E436D]' style={{ opacity: 0.3 }} />
+      <View className='absolute inset-0 rounded-full bg-[#ECEDF1] dark:bg-[#3E436D]' style={colorScheme == 'dark' ? { opacity: 0.3 } : { opacity: 1 }} />
 
       <View className='items-center justify-center'>
         <Image source={currentIcon} className='h-4 w-4' resizeMode='contain' />


### PR DESCRIPTION
## 🚀 Summary

This PR fixes the inconsistent appearance of the `RoundIconButton` component when the app is in Light Mode. 

The issue stemmed from missing theme-aware styles within the component, causing it to not visually match the Light Mode design guidelines.

## 🧩 Related Issues / Tasks

- Closes #6 

## 🛠️ Type of Change

- [X] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 🧨 Breaking change
- [ ] 🔨 Enhancement/Refactor
- [ ] 📝 Documentation
- [ ] 📜 Other (please describe):

## ✅ Checklist

- [X] The code is formatted with **Prettier** (`npm run format` or `npx prettier --write .`)
- [X] PR references a linked **Issue** or **Task number**
- [X] Tested on both iOS and Android devices/emulators
- [X] No unnecessary logs or commented-out code
- [X] UI changes, if any, have been reviewed visually
- [ ] All tests are passing (if applicable)
- [ ] Added or updated documentation where necessary

## 📸 Screenshots / Videos (UI changes only)

### Before
<img src='https://github.com/user-attachments/assets/efcc4edf-20be-4aee-bf17-0ee527b5a646' width='160' />

### After
<img src='https://github.com/user-attachments/assets/79df9173-65e9-4fd4-95b2-024a9a7f9c05' width='160' />

## 🧪 Test Plan

Visual testing of both the screens was done and screenshots uploaded above.