### PR TITLE
Integrates signup and signin with Zustand auth store

### DIFF
--- a/apps/frontend/app/(auth)/(signup)/info.tsx
+++ b/apps/frontend/app/(auth)/(signup)/info.tsx
@@ -1,20 +1,13 @@
 import { InputField, PrimaryButton } from '@/components';
 import { AlertStrings, Strings } from '@/constants';
-import {
-  formatPhoneNumber,
-  getUser,
-  signUp,
-  validateConfirmPassword,
-  validateName,
-  validatePassword,
-  validatePhone,
-} from '@/utils';
+import useAuthStore from '@/store/auth.store';
+import { formatPhoneNumber, validateConfirmPassword, validateName, validatePassword, validatePhone } from '@/utils';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { Alert, Text, View } from 'react-native';
 
 const SignUpInfo = () => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { signup, isLoading } = useAuthStore();
   const { email } = useLocalSearchParams<{ email: string }>();
   const [formData, setFormData] = useState({ name: '', email: email, password: '', confirmPassword: '', phone: '' });
 
@@ -32,16 +25,11 @@ const SignUpInfo = () => {
     if (!confirmPasswordValidationresult.isValid)
       return Alert.alert(AlertStrings.TITLE.ERROR, confirmPasswordValidationresult.error);
 
-    setIsSubmitting(true);
-
     try {
-      await signUp({ name, phone, email, password });
-      const user = await getUser();
-      router.replace({ pathname: '/welcome', params: { name: user?.user_metadata.name || '' } });
+      await signup({ name, phone, email, password });
+      router.replace({ pathname: '/welcome', params: { name } });
     } catch (err: any) {
       Alert.alert(AlertStrings.TITLE.ERROR, err.message);
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -54,7 +42,7 @@ const SignUpInfo = () => {
           label={Strings.signupInfo.NAME_LABEL}
           keyboardType='default'
           value={formData.name}
-          disabled={isSubmitting}
+          disabled={isLoading}
           onChangeText={(value) => setFormData((prev) => ({ ...prev, name: value }))}
         />
         <InputField
@@ -67,24 +55,24 @@ const SignUpInfo = () => {
           label={Strings.signupInfo.PHONE_LABEL}
           keyboardType='phone-pad'
           value={formatPhoneNumber(formData.phone)}
-          disabled={isSubmitting}
+          disabled={isLoading}
           onChangeText={(value) => setFormData((prev) => ({ ...prev, phone: value }))}
         />
         <InputField
           label={Strings.signupInfo.PASSWORD_LABEL}
           secureTextEntry
           value={formData.password}
-          disabled={isSubmitting}
+          disabled={isLoading}
           onChangeText={(value) => setFormData((prev) => ({ ...prev, password: value }))}
         />
         <InputField
           label={Strings.signupInfo.CONFIRM_PASSWORD_LABEL}
           secureTextEntry
           value={formData.confirmPassword}
-          disabled={isSubmitting}
+          disabled={isLoading}
           onChangeText={(value) => setFormData((prev) => ({ ...prev, confirmPassword: value }))}
         />
-        <PrimaryButton title={Strings.signupInfo.BUTTON_LABEL} isLoading={isSubmitting} onPress={submitForm} />
+        <PrimaryButton title={Strings.signupInfo.BUTTON_LABEL} isLoading={isLoading} onPress={submitForm} />
       </View>
     </View>
   );

--- a/apps/frontend/app/(auth)/_layout.tsx
+++ b/apps/frontend/app/(auth)/_layout.tsx
@@ -7,7 +7,7 @@ const AuthLayout = () => {
   return (
     <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
       <ScrollView className='screen-wrapper' keyboardShouldPersistTaps='handled'>
-        <View style={{ height: Dimensions.get('screen').height / (pathname === '/signupInfo' ? 3.5 : 2.5) }}>
+        <View style={{ height: Dimensions.get('screen').height / (pathname === '/info' ? 3.5 : 2.5) }}>
           <Image source={images.logo} className='header-logo' resizeMode='contain' />
         </View>
         <Slot />

--- a/apps/frontend/app/(auth)/signin.tsx
+++ b/apps/frontend/app/(auth)/signin.tsx
@@ -1,13 +1,14 @@
 import { images } from '@/assets';
 import { IconButton, InputField, PrimaryButton } from '@/components';
 import { AlertStrings, Strings } from '@/constants';
-import { getUser, signIn, validateEmail, validatePassword } from '@/utils';
+import useAuthStore from '@/store/auth.store';
+import { validateEmail, validatePassword } from '@/utils';
 import { router } from 'expo-router';
 import { useState } from 'react';
 import { Alert, Pressable, Text, View } from 'react-native';
 
 const SignIn = () => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { signin, isLoading, user } = useAuthStore();
   const [formData, setFormData] = useState({ email: '', password: '' });
 
   const resetForm = () => {
@@ -22,16 +23,11 @@ const SignIn = () => {
     if (!emailValidationResult.isValid) return Alert.alert(AlertStrings.TITLE.ERROR, emailValidationResult.error);
     if (!passwordValidationResult.isValid) return Alert.alert(AlertStrings.TITLE.ERROR, passwordValidationResult.error);
 
-    setIsSubmitting(true);
-
     try {
-      await signIn({ email, password });
-      const user = await getUser();
-      router.replace({ pathname: '/welcome', params: { name: user?.user_metadata.name || '' } });
+      await signin({ email, password });
+      router.replace('/welcome');
     } catch (err: any) {
       Alert.alert(AlertStrings.TITLE.ERROR, err.message);
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -45,17 +41,17 @@ const SignIn = () => {
           label={Strings.login.EMAIL_LABEL}
           keyboardType='email-address'
           value={formData.email}
-          disabled={isSubmitting}
+          disabled={isLoading}
           onChangeText={(value) => setFormData((prev) => ({ ...prev, email: value }))}
         />
         <InputField
           label={Strings.login.PASSWORD_LABEL}
           secureTextEntry
           value={formData.password}
-          disabled={isSubmitting}
+          disabled={isLoading}
           onChangeText={(value) => setFormData((prev) => ({ ...prev, password: value }))}
         />
-        <PrimaryButton title={Strings.login.BUTTON_LABEL} isLoading={isSubmitting} onPress={submitForm} />
+        <PrimaryButton title={Strings.login.BUTTON_LABEL} isLoading={isLoading} onPress={submitForm} />
       </View>
 
       {/* Socials & Footer */}
@@ -66,12 +62,12 @@ const SignIn = () => {
           <View className='divider-line' />
         </View>
         <View className='social-auth-row'>
-          <IconButton icon={images.google} disabled={isSubmitting} onPress={() => {}} />
-          <IconButton icon={images.facebook} disabled={isSubmitting} onPress={() => {}} />
+          <IconButton icon={images.google} disabled={isLoading} onPress={() => {}} />
+          <IconButton icon={images.facebook} disabled={isLoading} onPress={() => {}} />
         </View>
         <View className='footer-wrapper'>
           <Text className='footer-txt'>{Strings.login.NO_ACCOUNT_TEXT}</Text>
-          <Pressable disabled={isSubmitting} onPress={() => router.replace('/(auth)/(signup)')}>
+          <Pressable disabled={isLoading} onPress={() => router.replace('/(auth)/(signup)')}>
             <Text className='footer-link'>{Strings.login.SIGNUP_CTA}</Text>
           </Pressable>
         </View>

--- a/apps/frontend/app/(auth)/welcome.tsx
+++ b/apps/frontend/app/(auth)/welcome.tsx
@@ -1,11 +1,12 @@
 import { PrimaryButton } from '@/components';
 import { AlertStrings, Strings } from '@/constants';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useAuthStore } from '@/store';
+import { router } from 'expo-router';
 import { useState } from 'react';
 import { Alert, Text, View } from 'react-native';
 
 const Welcome = () => {
-  const { name } = useLocalSearchParams<{ name: string }>();
+  const { user } = useAuthStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const proceed = async () => {
@@ -24,7 +25,7 @@ const Welcome = () => {
     <View className='content-wrapper'>
       <View className='welcome-header-wrapper'>
         <Text className='welcome-header-txt'>
-          {Strings.welcome.SCREEN_GREETING} {name.split(' ')[0]}! 👋
+          {Strings.welcome.SCREEN_GREETING} {user?.user_metadata.name.split(' ')[0]}! 👋
         </Text>
         <Text className='welcome-header-txt'>{Strings.welcome.SCREEN_TITLE}</Text>
         <Text className='welcome-sub-header-txt'>{Strings.welcome.WELCOME_TEXT}</Text>

--- a/apps/frontend/app/(tabs)/_layout.tsx
+++ b/apps/frontend/app/(tabs)/_layout.tsx
@@ -1,18 +1,10 @@
 import { images } from '@/assets';
 import { TabBarIcon } from '@/components';
-import { useAuthStore } from '@/store';
 import { Tabs } from 'expo-router';
-import { useEffect } from 'react';
 import { useColorScheme } from 'react-native';
 
 const TabLayout = () => {
-  // temporary - remove when Signin/Signup integrated with Zustand
-  const { fetchAuthenticatedUser } = useAuthStore();
   const isDark = useColorScheme() === 'dark';
-
-  useEffect(() => {
-    fetchAuthenticatedUser();
-  }, []);
 
   return (
     <Tabs

--- a/apps/frontend/store/auth.store.ts
+++ b/apps/frontend/store/auth.store.ts
@@ -1,4 +1,4 @@
-import { getUser, signOut, updateUser } from '@/utils';
+import { getUser, signIn, signOut, signUp, updateUser } from '@/utils';
 import { create } from 'zustand';
 
 const useAuthStore = create<AuthState>((set) => ({
@@ -37,6 +37,8 @@ const useAuthStore = create<AuthState>((set) => ({
       const user = await getUser();
       if (user) {
         set({ user: user });
+      } else {
+        set({ isAuthenticated: false, user: null });
       }
     } catch (err) {
       console.log('updateUserProfile error', err);
@@ -54,6 +56,44 @@ const useAuthStore = create<AuthState>((set) => ({
       set({ isAuthenticated: false, user: null });
     } catch (err) {
       console.log('logout error', err);
+      throw new Error(err as any);
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  signin: async (signInParams: SignInParams) => {
+    set({ isLoading: true });
+
+    try {
+      await signIn({ ...signInParams });
+      const user = await getUser();
+      if (user) {
+        set({ isAuthenticated: true, user: user });
+      } else {
+        set({ isAuthenticated: false, user: null });
+      }
+    } catch (err) {
+      console.log('signin error', err);
+      throw new Error(err as any);
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  signup: async (signUpParams: SignUpParams) => {
+    set({ isLoading: true });
+
+    try {
+      await signUp({ ...signUpParams });
+      const user = await getUser();
+      if (user) {
+        set({ isAuthenticated: true, user: user });
+      } else {
+        set({ isAuthenticated: false, user: null });
+      }
+    } catch (err) {
+      console.log('signup error', err);
       throw new Error(err as any);
     } finally {
       set({ isLoading: false });

--- a/apps/frontend/types/store.d.ts
+++ b/apps/frontend/types/store.d.ts
@@ -9,5 +9,7 @@ interface AuthState {
 
   fetchAuthenticatedUser: () => Promise<void>;
   updateProfile: (newInfo: UpdateUserParams) => Promise<void>;
-  signout: () => Promsise<void>;
+  signout: () => Promise<void>;
+  signin: (signInParams: SignInParams) => Promise<void>;
+  signup: (signUpParams: SignUpParams) => Promise<void>;
 }


### PR DESCRIPTION
## 🚀 Summary

Integrates signin and signup to use zustand's auth store instead of doing it on UI level

## 🧩 Related Issues / Tasks

Closes #30 

## 🛠️ Type of Change

- [ ] 🐞 Bug fix
- [X] ✨ New feature
- [ ] 🧨 Breaking change
- [X] 🔨 Enhancement/Refactor
- [ ] 📝 Documentation
- [ ] 📜 Other (please describe):

## ✅ Checklist

- [X] The code is formatted with **Prettier** (`npm run format` or `npx prettier --write .`)
- [X] PR references a linked **Issue** or **Task number**
- [X] Tested on both iOS and Android devices/emulators
- [X] No unnecessary logs or commented-out code
- [ ] UI changes, if any, have been reviewed visually
- [ ] All tests are passing (if applicable)
- [ ] Added or updated documentation where necessary

## 🧪 Test Plan

1. Signin if already having an account, it seamlessly routes the user to the welcome screen and then further to homescreen
2. Signup by entering valid info, it routes the user to welcome screen and then homescreen
