### PR TITLE
Integrates useStatStore in Profile to display user stats; fetches on …

### DIFF
--- a/apps/frontend/app/(tabs)/(profile)/index.tsx
+++ b/apps/frontend/app/(tabs)/(profile)/index.tsx
@@ -1,7 +1,7 @@
 import { icons } from '@/assets';
 import { AccountInfo, DividerX, MenuOption, SecondaryButton, ToggleButton } from '@/components';
 import { AlertStrings, screenContentWrapperStyle, Strings } from '@/constants';
-import { useAuthStore, useProfileStore } from '@/store';
+import { useAuthStore, useProfileStore, useStatStore } from '@/store';
 import cn from 'clsx';
 import { router } from 'expo-router';
 import { useState } from 'react';
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 const Profile = () => {
   const isDark = useColorScheme() === 'dark';
   const { profile } = useProfileStore();
+  const { stat } = useStatStore();
   const { isLoading, signout } = useAuthStore();
   const [infoTermFilter, setInfoTermFilter] = useState<TradingInfoTerm>('30d');
 
@@ -63,7 +64,9 @@ const Profile = () => {
             <View className='stats-content flex-row'>
               <View className='col-left flex-1 gap-y-6'>
                 <View className='gap-y-2'>
-                  <Text className='text-base-dark font-clashDisplay-medium text-2xl dark:text-base-white'>5</Text>
+                  <Text className='text-base-dark font-clashDisplay-medium text-2xl dark:text-base-white'>
+                    {stat?.totalTrades ?? 0}
+                  </Text>
                   <Text className='font-satoshi-medium text-base text-neutral dark:text-neutral-400'>
                     {Strings.profile.TOTAL_TRADES_LABEL}
                   </Text>
@@ -71,7 +74,7 @@ const Profile = () => {
 
                 <View className='gap-y-2'>
                   <Text className='text-base-dark font-clashDisplay-medium text-2xl dark:text-base-white'>
-                    4.3 Minutes
+                    {stat?.avgReleaseTime ?? 0} Minutes
                   </Text>
                   <Text className='font-satoshi text-base text-neutral dark:text-neutral-400'>
                     {Strings.profile.AVG_RELEASE_LABEL}
@@ -81,14 +84,18 @@ const Profile = () => {
 
               <View className='col-right flex-1 gap-y-6'>
                 <View className='gap-y-2'>
-                  <Text className='text-base-dark font-clashDisplay-medium text-2xl dark:text-base-white'>100%</Text>
+                  <Text className='text-base-dark font-clashDisplay-medium text-2xl dark:text-base-white'>
+                    {stat?.completionRate ?? 0}%
+                  </Text>
                   <Text className='font-satoshi text-base text-neutral dark:text-neutral-400'>
                     {Strings.profile.COMPLETION_RATE_LABEL}
                   </Text>
                 </View>
 
                 <View className='gap-y-2'>
-                  <Text className='text-base-dark font-clashDisplay-medium text-2xl dark:text-base-white'>100%</Text>
+                  <Text className='text-base-dark font-clashDisplay-medium text-2xl dark:text-base-white'>
+                    {stat?.avgPayTime ?? 0} Minutes
+                  </Text>
                   <Text className='font-satoshi text-base text-neutral dark:text-neutral-400'>
                     {Strings.profile.AVG_PAY_LABEL}
                   </Text>

--- a/apps/frontend/models/stat/stat.d.ts
+++ b/apps/frontend/models/stat/stat.d.ts
@@ -1,0 +1,7 @@
+interface Stat {
+  userId: string;
+  totalTrades: number;
+  completionRate: number;
+  avgReleaseTime: number;
+  avgPayTime: number;
+}

--- a/apps/frontend/store/auth.store.ts
+++ b/apps/frontend/store/auth.store.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import useCryptotore from './crypto.store';
 import useFiatStore from './fiat.store';
 import useProfileStore from './profile.store';
+import useStatStore from './stats.store';
 
 const useAuthStore = create<AuthState>((set) => ({
   user: null,
@@ -92,6 +93,7 @@ const useAuthStore = create<AuthState>((set) => ({
         await useFiatStore.getState().fetchFiats();
         await useCryptotore.getState().fetchCryptos();
         await useProfileStore.getState().fetchProfile(user.id);
+        await useStatStore.getState().fetchStat(user.id);
         set({ isAuthenticated: true, user: user });
       } else {
         set({ isAuthenticated: false, user: null });

--- a/apps/frontend/store/index.ts
+++ b/apps/frontend/store/index.ts
@@ -1,3 +1,4 @@
 export { default as useAuthStore } from './auth.store';
 export { default as useFiatStore } from './fiat.store';
 export { default as useProfileStore } from './profile.store';
+export { default as useStatStore } from './stats.store';

--- a/apps/frontend/store/stats.store.ts
+++ b/apps/frontend/store/stats.store.ts
@@ -1,0 +1,23 @@
+import { fetchStat } from '@/supabase';
+import { create } from 'zustand';
+
+const useStatStore = create<StatState>((set) => ({
+  stat: null,
+  isLoading: false,
+
+  fetchStat: async (userId: string) => {
+    set({ isLoading: true });
+
+    try {
+      const stat = await fetchStat(userId);
+      set({ stat });
+    } catch (err: any) {
+      console.log('fetchCryptos error', err);
+      throw new Error(err.message);
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));
+
+export default useStatStore;

--- a/apps/frontend/supabase/index.ts
+++ b/apps/frontend/supabase/index.ts
@@ -3,3 +3,4 @@ export * from './client';
 export * from './crypto';
 export * from './fiat';
 export * from './profile';
+export * from './stats';

--- a/apps/frontend/supabase/mapUtils/index.ts
+++ b/apps/frontend/supabase/mapUtils/index.ts
@@ -1,3 +1,4 @@
 export * from './crypto';
 export * from './fiat';
 export * from './profile';
+export * from './stats';

--- a/apps/frontend/supabase/mapUtils/stats.ts
+++ b/apps/frontend/supabase/mapUtils/stats.ts
@@ -1,0 +1,26 @@
+const statToDbMap: Record<keyof Stat, string> = {
+  userId: 'user_id',
+  totalTrades: 'total_trades',
+  completionRate: 'completion_rate',
+  avgReleaseTime: 'avg_release_time',
+  avgPayTime: 'avg_pay_time',
+};
+
+const dbToStatMap: Record<string, keyof Stat> = Object.entries(statToDbMap).reduce(
+  (acc, [camelKey, snakeKey]) => {
+    acc[snakeKey] = camelKey as keyof Stat;
+    return acc;
+  },
+  {} as Record<string, keyof Stat>,
+);
+
+// snake_case → camelCase
+const convertToStatKeys = (obj: Record<string, any>): Stat => {
+  return Object.entries(obj).reduce((acc, [snakeKey, value]) => {
+    const camelKey = dbToStatMap[snakeKey];
+    if (camelKey) acc[camelKey] = value;
+    return acc;
+  }, {} as Partial<Stat>) as Stat;
+};
+
+export { convertToStatKeys };

--- a/apps/frontend/supabase/stats.ts
+++ b/apps/frontend/supabase/stats.ts
@@ -1,0 +1,12 @@
+import supabaseClient from './client';
+import { convertToStatKeys } from './mapUtils';
+
+const fetchStat = async (userId: string): Promise<Stat> => {
+  const { data, error } = await supabaseClient.from('stats').select('*').eq('user_id', userId).single();
+
+  if (error) throw new Error(error.message);
+  const stat = convertToStatKeys(data);
+  return stat;
+};
+
+export { fetchStat };

--- a/apps/frontend/types/store.d.ts
+++ b/apps/frontend/types/store.d.ts
@@ -29,3 +29,10 @@ interface CryptoState {
 
   fetchCryptos: () => Promise<void>;
 }
+
+interface StatState {
+  stat: Stat | null;
+  isLoading: boolean;
+
+  fetchStat: (userId: string) => Promise<void>;
+}


### PR DESCRIPTION
## 🚀 Summary

Add stat store integration to profile component

- Imported useStatStore in the profile component to access user statistics.
- Updated profile display to show total trades, average release time, completion rate, and average pay time using data from the stat store.
- Enhanced auth store to fetch user statistics upon authentication.
- Exported useStatStore from the store index and included in supabase exports.

## 🧩 Related Issues / Tasks

## 🛠️ Type of Change

- [ ] 🐞 Bug fix
- [X] ✨ New feature
- [ ] 🧨 Breaking change
- [X] 🔨 Enhancement/Refactor
- [ ] 📝 Documentation
- [ ] 📜 Other (please describe):

## ✅ Checklist

- [X] The code is formatted with **Prettier** (`npm run format` or `npx prettier --write .`)
- [ ] PR references a linked **Issue** or **Task number**
- [X] Tested on both iOS and Android devices/emulators
- [X] No unnecessary logs or commented-out code
- [X] UI changes, if any, have been reviewed visually
- [ ] All tests are passing (if applicable)
- [ ] Added or updated documentation where necessary

## 🧪 Test Plan

1. Verified stats display correctly in the Profile component.
2. Confirmed stats are fetched on authentication.
3. Checked that exports from store and Supabase index include useStatStore.
