### PR TITLE
Optimizes P2P and Advert layouts with cleaner imports, header updates…

### DIFF
--- a/apps/frontend/app/(p2p)/(advert)/_layout.tsx
+++ b/apps/frontend/app/(p2p)/(advert)/_layout.tsx
@@ -19,9 +19,12 @@ const AdvertLayout = () => {
           backgroundColor: isDark ? '#000000' : '#FFFFFF',
         },
         headerTransparent: true,
+        headerStyle: {
+          backgroundColor: isDark ? '#000000' : '#FFFFFF',
+        },
         headerTitleAlign: 'center',
         headerTitleStyle: {
-          color: isDark ? '#FFFFFF' : '#23262F',
+          color: isDark ? '#FFFFFF' : '#000000',
           fontWeight: 'semibold',
           fontFamily: 'poppins',
           fontSize: 18,

--- a/apps/frontend/app/(p2p)/_layout.tsx
+++ b/apps/frontend/app/(p2p)/_layout.tsx
@@ -17,7 +17,6 @@ const P2PLayout = () => {
         screenOptions={() => ({
           animation: 'shift',
           headerTransparent: true,
-          headerShown: false,
           headerTitleAlign: 'center',
           tabBarShowLabel: false,
           headerTitleStyle: {
@@ -92,6 +91,7 @@ const P2PLayout = () => {
         <Tabs.Screen
           name='(advert)'
           options={{
+            headerShown: false,
             title: Strings.myAds.HEADER_TITLE,
             tabBarIcon: ({ focused }) => (
               <TabBarIcon


### PR DESCRIPTION
## 🚀 Summary

updated the usage of header for adverts to remove add icon from post advert page and have more granular control over them

## 🧩 Related Issues / Tasks
NA

## 🛠️ Type of Change

- [X] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 🧨 Breaking change
- [X] 🔨 Enhancement/Refactor
- [ ] 📝 Documentation
- [ ] 📜 Other (please describe):

## ✅ Checklist

- [X] The code is formatted with **Prettier** (`npm run format` or `npx prettier --write .`)
- [X] PR references a linked **Issue** or **Task number** if any
- [X] Tested on both iOS and Android devices/emulators
- [X] No unnecessary logs or commented-out code
- [X] UI changes, if any, have been reviewed visually
- [ ] All tests are passing (if applicable)
- [ ] Added or updated documentation where necessary

## 📸 Screenshots / Videos (UI changes only)
NA

## 🧪 Test Plan

1. Go to post advert screen and then we can no more call edit screen again and again.
