### PR TITLE
Fix SignIn Bug After App Reload

### DIFF
--- a/apps/frontend/app/(auth)/(signup)/index.tsx
+++ b/apps/frontend/app/(auth)/(signup)/index.tsx
@@ -20,8 +20,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 const Signup = () => {
   const isIOS = Platform.OS === 'ios';
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({ email: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const resetForm = () => {
     setFormData({ email: '' });

--- a/apps/frontend/app/(auth)/(signup)/info.tsx
+++ b/apps/frontend/app/(auth)/(signup)/info.tsx
@@ -1,7 +1,7 @@
 import { images } from '@/assets';
 import { InputField, PhoneInputField, PrimaryButton } from '@/components';
 import { AlertStrings, Strings } from '@/constants';
-import { useAuth, useCountry, useMarket } from '@/hooks';
+import { useAuth, useCountry } from '@/hooks';
 import {
   formatPhoneNumber,
   trimPhoneNumber,
@@ -16,7 +16,6 @@ import { Alert, Dimensions, Image, KeyboardAvoidingView, Platform, ScrollView, T
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 const SignUpInfo = () => {
-  const { fetchAllTickers } = useMarket();
   const { signup, isLoading } = useAuth();
   const { currentCountry } = useCountry();
   const { email } = useLocalSearchParams<{ email: string }>();
@@ -50,7 +49,6 @@ const SignUpInfo = () => {
 
     try {
       await signup({ email, password }, profileData);
-      await fetchAllTickers();
       router.replace('/welcome');
     } catch (err: any) {
       Alert.alert(AlertStrings.TITLE.ERROR, err.message);

--- a/apps/frontend/app/(auth)/signin.tsx
+++ b/apps/frontend/app/(auth)/signin.tsx
@@ -1,7 +1,7 @@
 import { images } from '@/assets';
 import { IconButton, InputField, PrimaryButton } from '@/components';
 import { AlertStrings, Strings } from '@/constants';
-import { useAuth, useMarket } from '@/hooks';
+import { useAuth } from '@/hooks';
 import { validateEmail, validatePassword } from '@/utils';
 import cn from 'clsx';
 import { router } from 'expo-router';
@@ -21,8 +21,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 const SignIn = () => {
   const isIOS = Platform.OS === 'ios';
-
-  const { fetchAllTickers } = useMarket();
   const { signin, isLoading } = useAuth();
 
   const [formData, setFormData] = useState({ email: '', password: '' });
@@ -41,7 +39,6 @@ const SignIn = () => {
 
     try {
       await signin({ email, password });
-      await fetchAllTickers();
       router.replace('/welcome');
     } catch (err: any) {
       Alert.alert(AlertStrings.TITLE.ERROR, err.message);

--- a/apps/frontend/app/index.tsx
+++ b/apps/frontend/app/index.tsx
@@ -1,4 +1,5 @@
-import { useAuth, useKyc, useMarket } from '@/hooks';
+import { useAuth, useMarket } from '@/hooks';
+import { useAppDataStore } from '@/store';
 import { disableFontScaling } from '@/utils/fontScale';
 import { Redirect } from 'expo-router';
 import { useEffect } from 'react';
@@ -7,22 +8,23 @@ import { Text, View } from 'react-native';
 disableFontScaling();
 
 const Index = () => {
-  const { isLoading: isKycLoading, fetchKyc } = useKyc();
   const { isLoading: isTickerLoading, fetchAllTickers } = useMarket();
-  const { isLoading, isAuthenticated, fetchAuthenticatedUser } = useAuth();
+  const { isLoading: isAppDataLoading, fetchAppData } = useAppDataStore();
+  const { isLoading: isAuthLoading, isAuthenticated, fetchAuthenticatedUser } = useAuth();
 
   useEffect(() => {
+    fetchAppData();
     fetchAuthenticatedUser();
   }, []);
 
   useEffect(() => {
-    if (!isLoading && isAuthenticated) {
+    if (!isAppDataLoading) {
+      fetchAuthenticatedUser();
       fetchAllTickers();
-      fetchKyc();
     }
-  }, [isLoading]);
+  }, [isAppDataLoading]);
 
-  if (!isLoading && !isTickerLoading && !isKycLoading) {
+  if (!isAppDataLoading && !isAuthLoading && !isTickerLoading) {
     return <Redirect href={isAuthenticated ? '/(tabs)' : '/signin'} />;
   }
 

--- a/apps/frontend/store/appData.store.ts
+++ b/apps/frontend/store/appData.store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import useAdStore from './ad.store';
+import useCountryStore from './country.store';
+import useCryptotore from './crypto.store';
+import usePayMethodTypeStore from './payMethodType.store';
+
+const useAppDataStore = create<AppDataState>((set) => ({
+  isLoading: false,
+
+  fetchAppData: async () => {
+    set({ isLoading: true });
+
+    try {
+      await useAdStore.getState().fetchAds();
+      await useCryptotore.getState().fetchCryptos();
+      await useCountryStore.getState().fetchCountries();
+      await usePayMethodTypeStore.getState().fetchPayMethodTypes();
+    } catch (error: any) {
+      console.log('fetchAppData error', error);
+      throw new Error(error.message);
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));
+
+export default useAppDataStore;

--- a/apps/frontend/store/auth.store.ts
+++ b/apps/frontend/store/auth.store.ts
@@ -1,10 +1,7 @@
 import { getUser, signIn, signOut, signUp } from '@/supabase';
 import { create } from 'zustand';
-import useAdStore from './ad.store';
-import useCountryStore from './country.store';
-import useCryptotore from './crypto.store';
+import useKycStore from './kyc.store';
 import usePayMethodStore from './payMethod.store';
-import usePayMethodTypeStore from './payMethodType.store';
 import useProfileStore from './profile.store';
 import useReviewStore from './review.store';
 import useStatsStore from './stats.store';
@@ -38,14 +35,9 @@ const useAuthStore = create<AuthState>((set) => ({
           avatarUrl: '',
           createdAt: user.created_at,
         };
-
-        await useAdStore.getState().fetchAds();
-        await useCryptotore.getState().fetchCryptos();
-        await useCountryStore.getState().fetchCountries();
-        await usePayMethodTypeStore.getState().fetchPayMethodTypes();
-
         await useProfileStore.getState().createProfile(profile);
 
+        await useKycStore.getState().fetchKyc();
         await useStatsStore.getState().createStats(user.id);
         await useStatsStore.getState().fetchStats(user.id);
         await useReviewStore.getState().fetchReviews(user.id);
@@ -70,11 +62,7 @@ const useAuthStore = create<AuthState>((set) => ({
       const user = await getUser();
 
       if (user) {
-        await useAdStore.getState().fetchAds();
-        await useCryptotore.getState().fetchCryptos();
-        await useCountryStore.getState().fetchCountries();
-        await usePayMethodTypeStore.getState().fetchPayMethodTypes();
-
+        await useKycStore.getState().fetchKyc();
         await useStatsStore.getState().fetchStats(user.id);
         await useProfileStore.getState().fetchProfile(user.id);
         await useReviewStore.getState().fetchReviews(user.id);
@@ -113,11 +101,7 @@ const useAuthStore = create<AuthState>((set) => ({
       const user = await getUser();
 
       if (user) {
-        await useAdStore.getState().fetchAds();
-        await useCryptotore.getState().fetchCryptos();
-        await useCountryStore.getState().fetchCountries();
-        await usePayMethodTypeStore.getState().fetchPayMethodTypes();
-
+        await useKycStore.getState().fetchKyc();
         await useStatsStore.getState().fetchStats(user.id);
         await useReviewStore.getState().fetchReviews(user.id);
         await useProfileStore.getState().fetchProfile(user.id);

--- a/apps/frontend/store/index.ts
+++ b/apps/frontend/store/index.ts
@@ -1,4 +1,5 @@
 export { default as useAdStore } from './ad.store';
+export { default as useAppDataStore } from './appData.store';
 export { default as useAuthStore } from './auth.store';
 export { default as useCountryStore } from './country.store';
 export { default as useKycStore } from './kyc.store';

--- a/apps/frontend/store/kyc.store.ts
+++ b/apps/frontend/store/kyc.store.ts
@@ -1,7 +1,6 @@
 import { KycStatus, RequirementStatus } from '@/models';
 import { delay } from '@/utils';
 import { create } from 'zustand';
-import useAuthStore from './auth.store';
 import useProfileStore from './profile.store';
 
 const useKycStore = create<KycState>((set) => ({
@@ -13,14 +12,13 @@ const useKycStore = create<KycState>((set) => ({
 
     try {
       const profile = useProfileStore.getState().profile;
-      const user = useAuthStore.getState().user;
       set({
         kyc: {
           id: 'kyc-1',
           userId: profile?.id ?? '',
           name: `${profile?.firstName ?? ''} ${profile?.lastName ?? ''}`,
-          email: user?.email,
-          phone: user?.user_metadata?.phone,
+          email: profile?.email ?? '',
+          phone: profile?.phone ?? '',
           address: '',
           countryId: '',
           emailStatus: RequirementStatus.NotVerified,

--- a/apps/frontend/types/store.d.ts
+++ b/apps/frontend/types/store.d.ts
@@ -93,3 +93,9 @@ interface KycState {
   updateKyc: (updates: Partial<Kyc>) => Promise<void>;
   verifyOtp: (code: string) => Promise<boolean>;
 }
+
+interface AppDataState {
+  isLoading: boolean;
+
+  fetchAppData: () => Promise<void>;
+}


### PR DESCRIPTION
## 🚀 Summary

This PR fixes a bug in the **SignIn** flow where users were unable to sign in properly after reloading the app. 

The issue was caused by session handling inconsistencies, which are now resolved to ensure a smoother authentication experience.

## 🧩 Related Issues / Tasks

*N/A*

## 🛠️ Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 🧨 Breaking change
- [x] 🔨 Enhancement/Refactor
- [ ] 📝 Documentation
- [ ] 📜 Other (please describe):

## ✅ Checklist

- [x] The code is formatted with **Prettier** (`npm run format` or `npx prettier --write .`)
- [ ] PR references a linked **Issue** or **Task number**
- [x] Tested on both iOS and Android devices/emulators
- [x] No unnecessary logs or commented-out code
- [x] UI changes, if any, have been reviewed visually
- [ ] All tests are passing (if applicable)
- [ ] Added or updated documentation where necessary

## 📸 Screenshots / Videos (UI changes only)

*N/A*

## 🧪 Test Plan

- Reloaded app and verified user can sign in without errors.
- Confirmed session persistence across reloads.
- Tested on both iOS and Android.
- Validated no regressions in sign-up or sign-out flows.
