### PR TITLE
Enhance Post Advert UI with 'Order Type' label and improved ToggleButton layout

### DIFF
--- a/apps/frontend/app/(p2p)/(advert)/(post)/index.tsx
+++ b/apps/frontend/app/(p2p)/(advert)/(post)/index.tsx
@@ -61,7 +61,7 @@ const PostAdvert = () => {
     <SafeAreaView className='screen-wrapper' edges={['bottom']}>
       <View className='content-wrapper'>
         <Text className='font-clashDisplay text-sm text-label dark:text-label-dark'>
-          {Strings.postAd.ORDER_TYPE_LABEL}
+          {Strings.postAd.AD_TYPE_LABEL}
         </Text>
         <ToggleButton
           value={adType}

--- a/apps/frontend/app/(p2p)/(advert)/(post)/index.tsx
+++ b/apps/frontend/app/(p2p)/(advert)/(post)/index.tsx
@@ -60,22 +60,23 @@ const PostAdvert = () => {
   return (
     <SafeAreaView className='screen-wrapper' edges={['bottom']}>
       <View className='content-wrapper'>
-        <View className='flex-row justify-center'>
-          <ToggleButton
-            value={adType}
-            items={[adTypeFilterItems[0], adTypeFilterItems[1]]}
-            activeButtonColors={{
-              [adTypeFilterItems[0].id]: 'bg-primary',
-              [adTypeFilterItems[1].id]: 'bg-error-500',
-            }}
-            activeLabelColors={{
-              [adTypeFilterItems[0].id]: 'text-base-dark',
-              [adTypeFilterItems[1].id]: 'text-base-white',
-            }}
-            onChange={(val) => setAdType(val)}
-          />
-        </View>
-
+        <Text className='font-clashDisplay text-sm text-label dark:text-label-dark'>
+          {Strings.postAd.ORDER_TYPE_LABEL}
+        </Text>
+        <ToggleButton
+          value={adType}
+          items={[adTypeFilterItems[0], adTypeFilterItems[1]]}
+          activeButtonColors={{
+            [adTypeFilterItems[0].id]: 'bg-primary',
+            [adTypeFilterItems[1].id]: 'bg-error-500',
+          }}
+          activeLabelColors={{
+            [adTypeFilterItems[0].id]: 'text-base-dark',
+            [adTypeFilterItems[1].id]: 'text-base-white',
+          }}
+          wrapperStyle='w-full h-10'
+          onChange={(val) => setAdType(val)}
+        />
         <Dropdown
           title='Select Cryptocurrency'
           items={cryptoNameFilterItemsStrict}

--- a/apps/frontend/constants/strings/index.ts
+++ b/apps/frontend/constants/strings/index.ts
@@ -97,6 +97,7 @@ const Strings = {
     BUTTON_NEXT_LABEL: 'Next Steps',
     HEADER_TITLE_INFO: 'Amount Info',
     PUBLISH_AD_LABEL: 'Publish Ad',
+    ORDER_TYPE_LABEL: 'Order Type',
   },
   errors: {
     EMAIL_ERROR: 'Please enter a valid email address',

--- a/apps/frontend/constants/strings/index.ts
+++ b/apps/frontend/constants/strings/index.ts
@@ -91,13 +91,13 @@ const Strings = {
     HEADER_TITLE: 'My Adverts',
   },
   postAd: {
-    HEADER_TITLE: 'Post Adverts',
-    EMPTY_STATE: 'No ads available',
+    HEADER_TITLE: 'Post Ad',
+    EMPTY_STATE: 'No ad available',
     PRICE_SETTING: 'Price Setting',
     BUTTON_NEXT_LABEL: 'Next Steps',
     HEADER_TITLE_INFO: 'Amount Info',
     PUBLISH_AD_LABEL: 'Publish Ad',
-    ORDER_TYPE_LABEL: 'Order Type',
+    AD_TYPE_LABEL: 'Ad Type',
   },
   errors: {
     EMAIL_ERROR: 'Please enter a valid email address',


### PR DESCRIPTION
## 🚀 Summary

Make the buy and sell toggle button as an input field type from header toggle tab style

## 🧩 Related Issues / Tasks
NA

## 🛠️ Type of Change

- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 🧨 Breaking change
- [x] 🔨 Enhancement/Refactor
- [ ] 📝 Documentation
- [ ] 📜 Other (please describe):

## ✅ Checklist

- [x] The code is formatted with **Prettier** (`npm run format` or `npx prettier --write .`)
- [x] PR references a linked **Issue** or **Task number**
- [x] Tested on both iOS and Android devices/emulators
- [x] No unnecessary logs or commented-out code
- [x] UI changes, if any, have been reviewed visually
- [ ] All tests are passing (if applicable)
- [ ] Added or updated documentation where necessary

## 🧪 Test Plan
NA
